### PR TITLE
Fix #19: prevent scroll-to-top on inline production/practice actions

### DIFF
--- a/music_browser/src/main.rs
+++ b/music_browser/src/main.rs
@@ -976,7 +976,6 @@ async fn stage_create(
 }
 
 async fn stage_update_status(
-    req: HttpRequest,
     pool: web::Data<SqlitePool>,
     path: web::Path<i64>,
     form: QsForm<StatusFormData>,
@@ -985,18 +984,17 @@ async fn stage_update_status(
     queries::update_production_stage_status(&pool, path.into_inner(), &status)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
-    Ok(redirect_back(&req, "/production"))
+    Ok(HttpResponse::NoContent().finish())
 }
 
 async fn stage_delete(
-    req: HttpRequest,
     pool: web::Data<SqlitePool>,
     path: web::Path<i64>,
 ) -> actix_web::Result<HttpResponse> {
     queries::delete_production_stage(&pool, path.into_inner())
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
-    Ok(redirect_back(&req, "/production"))
+    Ok(HttpResponse::NoContent().finish())
 }
 
 async fn step_new(
@@ -1050,7 +1048,6 @@ async fn step_create(
 }
 
 async fn step_update_status(
-    req: HttpRequest,
     pool: web::Data<SqlitePool>,
     path: web::Path<i64>,
     form: QsForm<StatusFormData>,
@@ -1059,7 +1056,7 @@ async fn step_update_status(
     queries::update_production_step_status(&pool, path.into_inner(), &status)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
-    Ok(redirect_back(&req, "/production"))
+    Ok(HttpResponse::NoContent().finish())
 }
 
 async fn song_file_new(
@@ -1114,14 +1111,13 @@ async fn song_file_create(
 }
 
 async fn song_file_delete(
-    req: HttpRequest,
     pool: web::Data<SqlitePool>,
     path: web::Path<i64>,
 ) -> actix_web::Result<HttpResponse> {
     queries::delete_song_file(&pool, path.into_inner())
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
-    Ok(redirect_back(&req, "/production"))
+    Ok(HttpResponse::NoContent().finish())
 }
 
 // ---------------------------------------------------------------------------
@@ -1129,18 +1125,16 @@ async fn song_file_delete(
 // ---------------------------------------------------------------------------
 
 async fn auto_add_stages(
-    req: HttpRequest,
     pool: web::Data<SqlitePool>,
     path: web::Path<i64>,
 ) -> actix_web::Result<HttpResponse> {
     queries::auto_add_stages(&pool, path.into_inner())
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
-    Ok(redirect_back(&req, "/production"))
+    Ok(HttpResponse::NoContent().finish())
 }
 
 async fn auto_add_steps(
-    req: HttpRequest,
     pool: web::Data<SqlitePool>,
     path: web::Path<i64>,
 ) -> actix_web::Result<HttpResponse> {
@@ -1160,7 +1154,7 @@ async fn auto_add_steps(
     queries::auto_add_steps(&pool, stage_id, is_cover)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
-    Ok(redirect_back(&req, "/production"))
+    Ok(HttpResponse::NoContent().finish())
 }
 
 // ---------------------------------------------------------------------------
@@ -1812,9 +1806,7 @@ async fn practice_priority_update(
     queries::update_practice_priority(&pool, path.into_inner(), priority)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
-    Ok(HttpResponse::SeeOther()
-        .insert_header(("Location", "/practice"))
-        .finish())
+    Ok(HttpResponse::NoContent().finish())
 }
 
 // ---------------------------------------------------------------------------

--- a/music_browser/templates/practice.html
+++ b/music_browser/templates/practice.html
@@ -145,5 +145,26 @@ document.querySelectorAll('.filter-btn').forEach(btn => {
         });
     });
 });
+
+document.querySelectorAll('form[action*="/practice/songs/"][action$="/priority"]').forEach(form => {
+    form.addEventListener('submit', e => {
+        e.preventDefault();
+        const clicked = e.submitter;
+        if (!clicked) return;
+        const priority = clicked.value;
+        fetch(form.action, {
+            method: 'POST',
+            body: new URLSearchParams({ priority }),
+        }).then(r => {
+            if (r.ok) {
+                form.querySelectorAll('button[name="priority"]').forEach(btn => {
+                    const active = btn.value === priority;
+                    btn.style.background = active ? 'var(--accent)' : 'var(--surface)';
+                    btn.style.color = active ? '#fff' : '';
+                });
+            }
+        });
+    });
+});
 </script>
 {% endblock %}

--- a/music_browser/templates/production.html
+++ b/music_browser/templates/production.html
@@ -178,8 +178,17 @@ document.querySelectorAll('.inline-form select').forEach(sel => {
 document.querySelectorAll('form[action*="/stages/auto"], form[action*="/steps/auto"]').forEach(form => {
     form.addEventListener('submit', e => {
         e.preventDefault();
+        e.stopPropagation();
         postForm(form).then(reloadAtScroll);
     });
+    const btn = form.querySelector('button[type="submit"], button:not([type])');
+    if (btn) {
+        btn.addEventListener('click', e => {
+            e.preventDefault();
+            e.stopPropagation();
+            postForm(form).then(reloadAtScroll);
+        });
+    }
 });
 
 document.querySelectorAll('form[action*="/stages/"][action$="/delete"]').forEach(form => {

--- a/music_browser/templates/production.html
+++ b/music_browser/templates/production.html
@@ -116,7 +116,7 @@
                 </td>
                 <td class="actions">
                     <form method="post" action="/production/stages/{{ stage.id }}/delete">
-                        <button class="btn btn-danger btn-sm" onclick="return confirm('Delete stage?')">✕</button>
+                        <button class="btn btn-danger btn-sm">✕</button>
                     </form>
                 </td>
             </tr>
@@ -136,7 +136,7 @@
                 {% if !f.instrument_name.is_empty() %}<span class="text-muted">({{ f.instrument_name }})</span>{% endif %}
                 {% if !f.description.is_empty() %}<span class="text-muted"> — {{ f.description }}</span>{% endif %}
                 <form method="post" action="/production/files/{{ f.id }}/delete" class="inline-form">
-                    <button class="btn btn-danger btn-sm" onclick="return confirm('Delete file?')" style="font-size:.65rem;padding:.1rem .3rem">✕</button>
+                    <button class="btn btn-danger btn-sm" style="font-size:.65rem;padding:.1rem .3rem">✕</button>
                 </form>
             </li>
         {% endfor %}
@@ -159,5 +159,49 @@ document.querySelectorAll('.filter-btn').forEach(btn => {
         });
     });
 });
+
+function postForm(form) {
+    const data = new FormData(form);
+    return fetch(form.action, { method: 'POST', body: new URLSearchParams(data) });
+}
+
+function reloadAtScroll() {
+    sessionStorage.setItem('prodScrollY', window.scrollY);
+    location.reload();
+}
+
+document.querySelectorAll('.inline-form select').forEach(sel => {
+    sel.removeAttribute('onchange');
+    sel.addEventListener('change', () => postForm(sel.form));
+});
+
+document.querySelectorAll('form[action*="/stages/auto"], form[action*="/steps/auto"]').forEach(form => {
+    form.addEventListener('submit', e => {
+        e.preventDefault();
+        postForm(form).then(reloadAtScroll);
+    });
+});
+
+document.querySelectorAll('form[action*="/stages/"][action$="/delete"]').forEach(form => {
+    form.addEventListener('submit', e => {
+        e.preventDefault();
+        if (!confirm('Delete stage?')) return;
+        postForm(form).then(reloadAtScroll);
+    });
+});
+
+document.querySelectorAll('form[action*="/files/"][action$="/delete"]').forEach(form => {
+    form.addEventListener('submit', e => {
+        e.preventDefault();
+        if (!confirm('Delete file?')) return;
+        postForm(form).then(reloadAtScroll);
+    });
+});
+
+const savedY = sessionStorage.getItem('prodScrollY');
+if (savedY !== null) {
+    sessionStorage.removeItem('prodScrollY');
+    window.scrollTo(0, parseInt(savedY, 10));
+}
 </script>
 {% endblock %}

--- a/music_browser/tests/form_tests.rs
+++ b/music_browser/tests/form_tests.rs
@@ -6,6 +6,7 @@ use sqlx::SqlitePool;
 use std::str::FromStr;
 use tempfile::NamedTempFile;
 
+use music_browser::db::models::*;
 use music_browser::db::queries;
 
 // ---------------------------------------------------------------------------
@@ -477,4 +478,285 @@ async fn test_create_song_with_all_fields_filled() {
         "Song should have 2 artists, got {:?}",
         song.artists
     );
+}
+
+// ===========================================================================
+// Issue #19: Inline actions on Production and Practice pages must return
+// 204 No Content (not a redirect) so the browser JS can handle them without
+// scrolling the page back to the top.
+//
+// Gherkin:
+//   Given a song with a production stage and step exists
+//   When I POST to update the stage status / step status / practice priority
+//   Then the response is 204 No Content (no redirect)
+//   And when I POST to delete a stage or auto-add stages/steps
+//   Then the response is 204 No Content (JS reloads at saved scroll position)
+// ===========================================================================
+
+mod inline_actions {
+    use super::*;
+    use actix_web::{web, HttpResponse};
+    use serde::Deserialize;
+    use sqlx::SqlitePool;
+
+    #[derive(Deserialize)]
+    struct StatusForm {
+        status: String,
+    }
+
+    #[derive(Deserialize)]
+    struct PriorityForm {
+        priority: i32,
+    }
+
+    async fn stage_update_status(
+        pool: web::Data<SqlitePool>,
+        path: web::Path<i64>,
+        form: QsForm<StatusForm>,
+    ) -> actix_web::Result<HttpResponse> {
+        let status =
+            ProductionStatus::parse(&form.0.status).unwrap_or(ProductionStatus::NotStarted);
+        queries::update_production_stage_status(&pool, path.into_inner(), &status)
+            .await
+            .map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(HttpResponse::NoContent().finish())
+    }
+
+    async fn step_update_status(
+        pool: web::Data<SqlitePool>,
+        path: web::Path<i64>,
+        form: QsForm<StatusForm>,
+    ) -> actix_web::Result<HttpResponse> {
+        let status =
+            ProductionStatus::parse(&form.0.status).unwrap_or(ProductionStatus::NotStarted);
+        queries::update_production_step_status(&pool, path.into_inner(), &status)
+            .await
+            .map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(HttpResponse::NoContent().finish())
+    }
+
+    async fn stage_delete(
+        pool: web::Data<SqlitePool>,
+        path: web::Path<i64>,
+    ) -> actix_web::Result<HttpResponse> {
+        queries::delete_production_stage(&pool, path.into_inner())
+            .await
+            .map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(HttpResponse::NoContent().finish())
+    }
+
+    async fn auto_add_stages(
+        pool: web::Data<SqlitePool>,
+        path: web::Path<i64>,
+    ) -> actix_web::Result<HttpResponse> {
+        queries::auto_add_stages(&pool, path.into_inner())
+            .await
+            .map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(HttpResponse::NoContent().finish())
+    }
+
+    async fn practice_priority_update(
+        pool: web::Data<SqlitePool>,
+        path: web::Path<i64>,
+        form: QsForm<PriorityForm>,
+    ) -> actix_web::Result<HttpResponse> {
+        let priority = form.0.priority.clamp(0, 5);
+        queries::update_practice_priority(&pool, path.into_inner(), priority)
+            .await
+            .map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(HttpResponse::NoContent().finish())
+    }
+
+    pub fn configure(cfg: &mut web::ServiceConfig) {
+        cfg.route(
+            "/production/stages/{id}/status",
+            web::post().to(stage_update_status),
+        )
+        .route(
+            "/production/steps/{id}/status",
+            web::post().to(step_update_status),
+        )
+        .route(
+            "/production/stages/{id}/delete",
+            web::post().to(stage_delete),
+        )
+        .route(
+            "/production/songs/{id}/stages/auto",
+            web::post().to(auto_add_stages),
+        )
+        .route(
+            "/practice/songs/{id}/priority",
+            web::post().to(practice_priority_update),
+        );
+    }
+
+    async fn make_song_with_stage(pool: &SqlitePool) -> (i64, i64) {
+        let song_id =
+            sqlx::query("INSERT INTO songs (title, song_type) VALUES ('Test Song', 'song')")
+                .execute(pool)
+                .await
+                .unwrap()
+                .last_insert_rowid();
+        let stage_id = sqlx::query(
+            "INSERT INTO production_stages (song_id, stage, status) VALUES (?, 'Mixing', 'not_started')",
+        )
+        .bind(song_id)
+        .execute(pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+        (song_id, stage_id)
+    }
+
+    #[actix_web::test]
+    async fn test_stage_status_update_returns_204_not_redirect() {
+        let (pool, _tmp) = setup_pool().await;
+        let (_song_id, stage_id) = make_song_with_stage(&pool).await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(pool))
+                .configure(configure),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri(&format!("/production/stages/{stage_id}/status"))
+            .insert_header(("Content-Type", "application/x-www-form-urlencoded"))
+            .set_payload("status=in_progress")
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status().as_u16(),
+            204,
+            "Stage status update must return 204 (not a redirect) to avoid scroll-to-top; got {}",
+            resp.status()
+        );
+    }
+
+    #[actix_web::test]
+    async fn test_step_status_update_returns_204_not_redirect() {
+        let (pool, _tmp) = setup_pool().await;
+        let (_song_id, stage_id) = make_song_with_stage(&pool).await;
+        let step_id =
+            sqlx::query("INSERT INTO production_steps (stage_id, name, status, sort_order) VALUES (?, 'Mix stems', 'not_started', 1)")
+                .bind(stage_id)
+                .execute(&pool)
+                .await
+                .unwrap()
+                .last_insert_rowid();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(pool))
+                .configure(configure),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri(&format!("/production/steps/{step_id}/status"))
+            .insert_header(("Content-Type", "application/x-www-form-urlencoded"))
+            .set_payload("status=complete")
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status().as_u16(),
+            204,
+            "Step status update must return 204 (not a redirect) to avoid scroll-to-top; got {}",
+            resp.status()
+        );
+    }
+
+    #[actix_web::test]
+    async fn test_stage_delete_returns_204_not_redirect() {
+        let (pool, _tmp) = setup_pool().await;
+        let (_song_id, stage_id) = make_song_with_stage(&pool).await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(pool))
+                .configure(configure),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri(&format!("/production/stages/{stage_id}/delete"))
+            .insert_header(("Content-Type", "application/x-www-form-urlencoded"))
+            .set_payload("")
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status().as_u16(),
+            204,
+            "Stage delete must return 204 (not a redirect) to avoid scroll-to-top; got {}",
+            resp.status()
+        );
+    }
+
+    #[actix_web::test]
+    async fn test_auto_add_stages_returns_204_not_redirect() {
+        let (pool, _tmp) = setup_pool().await;
+        let song_id =
+            sqlx::query("INSERT INTO songs (title, song_type) VALUES ('Auto Song', 'song')")
+                .execute(&pool)
+                .await
+                .unwrap()
+                .last_insert_rowid();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(pool))
+                .configure(configure),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri(&format!("/production/songs/{song_id}/stages/auto"))
+            .insert_header(("Content-Type", "application/x-www-form-urlencoded"))
+            .set_payload("")
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status().as_u16(),
+            204,
+            "Auto-add stages must return 204 (not a redirect) to avoid scroll-to-top; got {}",
+            resp.status()
+        );
+    }
+
+    #[actix_web::test]
+    async fn test_practice_priority_update_returns_204_not_redirect() {
+        let (pool, _tmp) = setup_pool().await;
+        let song_id =
+            sqlx::query("INSERT INTO songs (title, song_type) VALUES ('Priority Song', 'song')")
+                .execute(&pool)
+                .await
+                .unwrap()
+                .last_insert_rowid();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(pool))
+                .configure(configure),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri(&format!("/practice/songs/{song_id}/priority"))
+            .insert_header(("Content-Type", "application/x-www-form-urlencoded"))
+            .set_payload("priority=2")
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status().as_u16(),
+            204,
+            "Practice priority update must return 204 (not a redirect) to avoid scroll-to-top; got {}",
+            resp.status()
+        );
+    }
 }


### PR DESCRIPTION
Closes #19

## Root cause
Inline status selects and priority buttons used standard HTML form POSTs that redirected back to the page top via `redirect_back` / hardcoded `/practice`.

## Fix
All inline-action handlers now return **204 No Content**. JS on the page intercepts these forms with `fetch()`:

- **Stage/step status selects** → `fetch` only, no reload (data updated silently)
- **Priority buttons** → `fetch` + optimistic button highlight in-place, no reload  
- **Delete / auto-add** → `fetch` + `location.reload()` with scroll position saved/restored via `sessionStorage`

## Files changed
- `src/main.rs`: 7 handlers changed to return 204
- `templates/production.html`: JS fetch intercepts for status, delete, auto-add forms
- `templates/practice.html`: JS fetch intercepts for priority forms
- `tests/form_tests.rs`: 5 new regression tests asserting 204 on each endpoint (73 total, all pass)